### PR TITLE
updated to dp-logging v1.6.0 and fixed useage of deprecated methods

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>com.github.ONSdigital</groupId>
             <artifactId>dp-logging</artifactId>
-            <version>release~1.1.0</version>
+            <version>v1.6.0</version>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION
- Update to latest version of dp-logging (v1.6.0).
- Fixed backwards compatibility issues (method signature changed).
- Refactored executeRequest into single method for reuse.