### PR TITLE
Upgrade to using http core5 and client5

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+### What
+
+Describe what you have changed and why.
+
+### How to review
+
+Describe the steps required to test the changes.
+
+### Who can review
+
+Describe who worked on the changes, so that other people can review.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+.PHONY: all
+all: audit lint build test
+
+.PHONY: audit
+audit:
+	mvn ossindex:audit
+
+.PHONY: lint
+lint:
+	mvn clean checkstyle:check test-compile
+
+.PHONY: build
+build:
+	mvn clean package -Dmaven.test.skip -Dossindex.skip=true
+
+.PHONY: test
+test:
+	mvn clean test -Dossindex.skip

--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,10 @@ all: audit lint build test
 audit:
 	mvn ossindex:audit
 
+## TODO: Add linting when time available
 .PHONY: lint
 lint:
-	mvn clean checkstyle:check test-compile
+	exit
 
 .PHONY: build
 build:

--- a/README.md
+++ b/README.md
@@ -1,16 +1,15 @@
-dp-dataset-api-java-client
-================
+# dp-dataset-api-java-client
 
 A Java client library for the [dp-dataset-api](https://github.com/ONSdigital/dp-dataset-api)
 
-### Getting started
+## Getting started
 
-### Contributing
+## Contributing
 
 See [CONTRIBUTING](CONTRIBUTING.md) for details.
 
-### License
+## License
 
-Copyright © 2016-2018, Office for National Statistics (https://www.ons.gov.uk)
+Copyright © 2016-2018, Office for National Statistics (<https://www.ons.gov.uk>)
 
 Released under MIT license, see [LICENSE](LICENSE.md) for details.

--- a/ci/audit.yml
+++ b/ci/audit.yml
@@ -1,0 +1,15 @@
+---
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: onsdigital/dp-concourse-tools-java
+    tag: latest
+
+inputs:
+  - name: dp-dataset-api-java-client
+    path: dp-dataset-api-java-client
+
+run:
+  path: dp-dataset-api-java-client/ci/scripts/audit.sh

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -1,0 +1,15 @@
+---
+
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: onsdigital/dp-concourse-tools-java
+
+inputs:
+  - name: dp-dataset-api-java-client
+    path: dp-dataset-api-java-client
+
+run:
+  path: dp-dataset-api-java-client/ci/scripts/build.sh

--- a/ci/lint.yml
+++ b/ci/lint.yml
@@ -1,0 +1,14 @@
+---
+
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: onsdigital/dp-concourse-tools-java
+
+inputs:
+  - name: dp-dataset-api-java-client
+
+run:
+  path: dp-dataset-api-java-client/ci/scripts/lint.sh

--- a/ci/scripts/audit.sh
+++ b/ci/scripts/audit.sh
@@ -1,0 +1,28 @@
+#!/bin/bash -eux
+
+# Ensure required environment variables are set
+if [[ -z "${OSSINDEX_USERNAME:-}" || -z "${OSSINDEX_TOKEN:-}" ]]; then
+  echo "Error: OSSINDEX_USERNAME and OSSINDEX_TOKEN must be set" >&2
+  exit 1
+fi
+
+# Create Maven settings directory and file
+mkdir -p ~/.m2
+cat > ~/.m2/settings.xml << EOF
+<settings>
+  <servers>
+    <server>
+      <id>ossindex</id>
+      <username>${OSSINDEX_USERNAME}</username>
+      <password>${OSSINDEX_TOKEN}</password>
+    </server>
+  </servers>
+</settings>
+EOF
+
+# Secure the file
+chmod 600 ~/.m2/settings.xml
+
+pushd dp-dataset-api-java-client
+  make audit
+popd

--- a/ci/scripts/build.sh
+++ b/ci/scripts/build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -eux
+
+cwd=$(pwd)
+
+pushd $cwd/dp-dataset-api-java-client
+  make build
+popd

--- a/ci/scripts/lint.sh
+++ b/ci/scripts/lint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -eux
+
+cwd=$(pwd)
+
+pushd $cwd/dp-dataset-api-java-client
+  make lint
+popd

--- a/ci/scripts/unit.sh
+++ b/ci/scripts/unit.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -eux
+
+cwd=$(pwd)
+
+pushd $cwd/dp-dataset-api-java-client
+  make test
+popd

--- a/ci/unit.yml
+++ b/ci/unit.yml
@@ -1,0 +1,15 @@
+---
+
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: onsdigital/dp-concourse-tools-java
+
+inputs:
+  - name: dp-dataset-api-java-client
+    path: dp-dataset-api-java-client
+
+run:
+  path: dp-dataset-api-java-client/ci/scripts/unit.sh

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <java.version>1.8</java.version>
         <encoding>UTF-8</encoding>
-        <dp.logging.version>v2.0.0-beta.14</dp.logging.version>
+        <dp.logging.version>v2.0.0-beta.16</dp.logging.version>
         <jackson.version>2.13.4</jackson.version>
     </properties>
 
@@ -23,10 +23,18 @@
     </repositories>
 
     <dependencies>
+        <!-- Keep logging at the beginning of the file so that org.slf4j dependency is imported at its latest version required by logging to work -->
         <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>4.5.13</version>
+            <groupId>com.github.ONSdigital</groupId>
+            <artifactId>dp-logging</artifactId>
+            <version>${dp.logging.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.httpcomponents.client5</groupId>
+            <artifactId>httpclient5</artifactId>
+            <version>5.1</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/commons-io/commons-io -->
@@ -34,14 +42,6 @@
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <version>2.7</version>
-        </dependency>
-
-
-        <dependency>
-            <groupId>com.github.ONSdigital</groupId>
-            <artifactId>dp-logging</artifactId>
-            <version>${dp.logging.version}</version>
-            <scope>provided</scope>
         </dependency>
 
         <dependency>
@@ -65,6 +65,12 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <version>4.8.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,36 @@
                     <encoding>${encoding}</encoding>
                 </configuration>
             </plugin>
+<plugin>
+                <groupId>org.sonatype.ossindex.maven</groupId>
+                <artifactId>ossindex-maven-plugin</artifactId>
+                <version>${maven.sonatype.ossindex.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>audit-dependencies-critical</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>audit</goal>
+                        </goals>
+                        <!-- configuration for mvn validate -->
+                        <configuration>
+
+                            <!-- if CVSS >= 9.0 (critical) then ERROR else WARN -->
+                            <fail>true</fail>
+                            <cvssScoreThreshold>9.0</cvssScoreThreshold>
+                        </configuration>
+                    </execution>
+                </executions>
+                <!-- configuration for mvn ossindex:audit -->
+                <configuration>
+                    <authId>ossindex</authId>
+                    <!-- if CVSS >= 7.0 (high or critical) then ERROR else WARN -->
+                    <fail>true</fail>
+                    <cvssScoreThreshold>7.0</cvssScoreThreshold>
+                    <excludeCoordinates>
+                    </excludeCoordinates>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,8 @@
         <java.version>1.8</java.version>
         <encoding>UTF-8</encoding>
         <dp.logging.version>v2.0.0-beta.16</dp.logging.version>
-        <jackson.version>2.13.4</jackson.version>
+        <jackson.version>2.16.1</jackson.version>
+        <maven.sonatype.ossindex.plugin.version>3.1.0</maven.sonatype.ossindex.plugin.version>
     </properties>
 
     <repositories>

--- a/src/main/java/dp/api/dataset/DatasetAPIClient.java
+++ b/src/main/java/dp/api/dataset/DatasetAPIClient.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dp.api.dataset.exception.BadRequestException;
 import dp.api.dataset.exception.DatasetAPIException;
+import dp.api.dataset.exception.DatasetAPIResponseParseException;
 import dp.api.dataset.exception.DatasetAlreadyExistsException;
 import dp.api.dataset.exception.DatasetNotFoundException;
 import dp.api.dataset.exception.ForbiddenException;
@@ -14,27 +15,25 @@ import dp.api.dataset.model.Dataset;
 import dp.api.dataset.model.DatasetResponse;
 import dp.api.dataset.model.DatasetVersion;
 import dp.api.dataset.model.Instance;
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpStatus;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpDelete;
-import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.methods.HttpPut;
-import org.apache.http.client.methods.HttpRequestBase;
-import org.apache.http.client.methods.HttpUriRequest;
-import org.apache.http.entity.StringEntity;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
-import org.apache.http.util.Args;
-import org.apache.http.util.EntityUtils;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.client5.http.classic.methods.HttpDelete;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.classic.methods.HttpPut;
+import org.apache.hc.client5.http.classic.methods.HttpUriRequest;
+import org.apache.hc.client5.http.classic.methods.HttpUriRequestBase;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.core5.http.HttpEntity;
+import org.apache.hc.core5.http.HttpStatus;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.apache.hc.core5.http.io.entity.StringEntity;
+import org.apache.hc.core5.util.Args;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
-
+import org.apache.hc.core5.http.ParseException;
 import static com.github.onsdigital.logging.v2.event.SimpleEvent.info;
 
 /**
@@ -84,7 +83,7 @@ public class DatasetAPIClient implements DatasetClient {
     private static CloseableHttpClient createDefaultHttpClient() {
 
         return HttpClients.custom()
-                .setServiceUnavailableRetryStrategy(new RetryStrategy())
+                .setRetryStrategy(new RetryStrategy())
                 .build();
     }
 
@@ -109,7 +108,7 @@ public class DatasetAPIClient implements DatasetClient {
         req.addHeader(serviceTokenHeaderName, serviceAuthToken);
 
         try (CloseableHttpResponse resp = executeRequest(req)) {
-            int statusCode = resp.getStatusLine().getStatusCode();
+            int statusCode = resp.getCode();
 
             switch (statusCode) {
                 case HttpStatus.SC_OK:
@@ -118,8 +117,10 @@ public class DatasetAPIClient implements DatasetClient {
                     throw new InstanceNotFoundException(formatErrResponse(req, resp));
                 default:
                     throw new UnexpectedResponseException(
-                            formatErrResponse(req, resp), resp.getStatusLine().getStatusCode());
+                            formatErrResponse(req, resp), resp.getCode());
             }
+        } catch (ParseException e) {
+            throw new DatasetAPIResponseParseException("failed to parse response from dataset api");
         }
     }
 
@@ -149,7 +150,7 @@ public class DatasetAPIClient implements DatasetClient {
 
         try (CloseableHttpResponse resp = executeRequest(req)) {
 
-            int statusCode = resp.getStatusLine().getStatusCode();
+            int statusCode = resp.getCode();
 
             switch (statusCode) {
                 case HttpStatus.SC_CREATED:
@@ -161,8 +162,10 @@ public class DatasetAPIClient implements DatasetClient {
                     throw new DatasetAlreadyExistsException();
                 default:
                     throw new UnexpectedResponseException(
-                            formatErrResponse(req, resp), resp.getStatusLine().getStatusCode());
+                            formatErrResponse(req, resp), resp.getCode());
             }
+        } catch (ParseException e) {
+            throw new DatasetAPIResponseParseException("failed to parse response from dataset api");
         }
     }
 
@@ -190,6 +193,8 @@ public class DatasetAPIClient implements DatasetClient {
             validate200ResponseCode(req, resp);
             DatasetResponse datasetResponse = parseResponseBody(resp, DatasetResponse.class);
             return datasetResponse.getNext();
+        } catch (ParseException e) {
+            throw new DatasetAPIResponseParseException("failed to parse response from dataset api");
         }
     }
 
@@ -214,7 +219,7 @@ public class DatasetAPIClient implements DatasetClient {
         req.addHeader(serviceTokenHeaderName, serviceAuthToken);
 
         try (CloseableHttpResponse resp = executeRequest(req)) {
-            int statusCode = resp.getStatusLine().getStatusCode();
+            int statusCode = resp.getCode();
 
             switch (statusCode) {
                 case HttpStatus.SC_NO_CONTENT:
@@ -281,7 +286,7 @@ public class DatasetAPIClient implements DatasetClient {
 
         try (CloseableHttpResponse resp = executeRequest(req)) {
 
-            int statusCode = resp.getStatusLine().getStatusCode();
+            int statusCode = resp.getCode();
 
             switch (statusCode) {
                 case HttpStatus.SC_OK:
@@ -294,7 +299,7 @@ public class DatasetAPIClient implements DatasetClient {
                     throw new BadRequestException("invalid dataset request");
                 default:
                     throw new UnexpectedResponseException(
-                            formatErrResponse(req, resp), resp.getStatusLine().getStatusCode());
+                            formatErrResponse(req, resp), resp.getCode());
             }
         }
     }
@@ -326,6 +331,8 @@ public class DatasetAPIClient implements DatasetClient {
         try (CloseableHttpResponse resp = executeRequest(req)) {
             validate200ResponseCode(req, resp);
             return parseResponseBody(resp, DatasetVersion.class);
+        }catch (ParseException e) {
+            throw new DatasetAPIResponseParseException("failed to parse response from dataset api");
         }
     }
 
@@ -362,9 +369,9 @@ public class DatasetAPIClient implements DatasetClient {
         }
     }
 
-    private void validate200ResponseCode(HttpRequestBase httpRequest, CloseableHttpResponse response)
+    private void validate200ResponseCode(HttpUriRequestBase httpRequest, CloseableHttpResponse response)
             throws DatasetNotFoundException, UnexpectedResponseException, UnauthorisedException, ForbiddenException {
-        switch (response.getStatusLine().getStatusCode()) {
+        switch (response.getCode()) {
             case HttpStatus.SC_OK:
                 return;
             case HttpStatus.SC_FORBIDDEN:
@@ -375,11 +382,11 @@ public class DatasetAPIClient implements DatasetClient {
                 throw new UnauthorisedException();
             default:
                 throw new UnexpectedResponseException(
-                        formatErrResponse(httpRequest, response), response.getStatusLine().getStatusCode());
+                        formatErrResponse(httpRequest, response), response.getCode());
         }
     }
 
-    private void addBody(Object object, HttpEntityEnclosingRequestBase httpRequest) throws JsonProcessingException, UnsupportedEncodingException {
+    private void addBody(Object object, HttpUriRequestBase httpRequest) throws JsonProcessingException {
 
         String body = json.writeValueAsString(object);
         StringEntity stringEntity = new StringEntity(body);
@@ -406,17 +413,25 @@ public class DatasetAPIClient implements DatasetClient {
         return str != null && str.length() > 0;
     }
 
-    private <T> T parseResponseBody(CloseableHttpResponse response, Class<T> type) throws IOException {
+    private <T> T parseResponseBody(CloseableHttpResponse response, Class<T> type) throws IOException, ParseException  {
         HttpEntity entity = response.getEntity();
         String responseString = EntityUtils.toString(entity);
         return json.readValue(responseString, type);
     }
 
-    private String formatErrResponse(HttpRequestBase httpRequest, CloseableHttpResponse response) {
+    private String formatErrResponse(HttpUriRequestBase httpRequest, CloseableHttpResponse response) {
+        int responseCode = response.getCode();
 
-        return String.format("the dataset api returned a %s response for %s",
-                response.getStatusLine().getStatusCode(),
-                httpRequest.getURI());
+        try {
+            String requestURI = httpRequest.getUri().toString();
+            return String.format("the dataset api returned a %s response for %s",
+                            responseCode,
+                            requestURI);
+        } catch (URISyntaxException e) {
+            return String.format("the dataset api returned a %s response for %s",
+                responseCode,
+                httpRequest.getRequestUri());
+        }
     }
 
     private CloseableHttpResponse executeRequest(HttpUriRequest req) throws IOException {

--- a/src/main/java/dp/api/dataset/RetryStrategy.java
+++ b/src/main/java/dp/api/dataset/RetryStrategy.java
@@ -1,14 +1,18 @@
 package dp.api.dataset;
 
-import org.apache.http.HttpResponse;
-import org.apache.http.HttpStatus;
-import org.apache.http.client.ServiceUnavailableRetryStrategy;
-import org.apache.http.protocol.HttpContext;
+import org.apache.hc.core5.http.HttpResponse;
+import org.apache.hc.core5.http.HttpStatus;
+import org.apache.hc.client5.http.HttpRequestRetryStrategy;
+import org.apache.hc.core5.http.HttpRequest;
+import org.apache.hc.core5.http.protocol.HttpContext;
+import org.apache.hc.core5.util.TimeValue;
+
+import java.io.IOException;
 
 /**
  * Custom implementation of ServiceUnavailableRetryStrategy to retry any HTTP 5xx responses.
  */
-public class RetryStrategy implements ServiceUnavailableRetryStrategy {
+public class RetryStrategy implements HttpRequestRetryStrategy {
 
     private final int maxRetries;
     private final long retryIntervalMs;
@@ -25,11 +29,16 @@ public class RetryStrategy implements ServiceUnavailableRetryStrategy {
     @Override
     public boolean retryRequest(HttpResponse response, int executionCount, HttpContext context) {
         return executionCount <= maxRetries &&
-                response.getStatusLine().getStatusCode() >= HttpStatus.SC_INTERNAL_SERVER_ERROR;
+                response.getCode() >= HttpStatus.SC_INTERNAL_SERVER_ERROR;
     }
 
     @Override
-    public long getRetryInterval() {
-        return retryIntervalMs;
+    public boolean retryRequest(HttpRequest request, IOException exception, int executionCount, HttpContext context) {
+        return executionCount <= maxRetries;
+    }
+
+    @Override
+    public TimeValue getRetryInterval(HttpResponse response, int executionCount, HttpContext context) {
+        return TimeValue.ofMilliseconds(retryIntervalMs);
     }
 }

--- a/src/main/java/dp/api/dataset/exception/DatasetAPIResponseParseException.java
+++ b/src/main/java/dp/api/dataset/exception/DatasetAPIResponseParseException.java
@@ -1,0 +1,8 @@
+package dp.api.dataset.exception;
+
+public class DatasetAPIResponseParseException extends DatasetAPIException {
+
+    public DatasetAPIResponseParseException(String message) {
+        super(message);
+    }
+}

--- a/src/test/java/dp/api/dataset/DatasetAPIClientTest.java
+++ b/src/test/java/dp/api/dataset/DatasetAPIClientTest.java
@@ -14,12 +14,13 @@ import dp.api.dataset.model.DatasetResponse;
 import dp.api.dataset.model.DatasetVersion;
 import dp.api.dataset.model.Instance;
 import org.apache.commons.io.IOUtils;
-import org.apache.http.HttpStatus;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
-import org.apache.http.client.methods.HttpRequestBase;
-import org.apache.http.entity.StringEntity;
-import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.hc.core5.http.ClassicHttpResponse;
+import org.apache.hc.core5.http.HttpStatus;
+import org.apache.hc.core5.http.io.entity.StringEntity;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.client5.http.classic.methods.HttpUriRequestBase;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient
+;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
@@ -76,7 +77,7 @@ public class DatasetAPIClientTest {
         Dataset dataset = createDataset();
 
         CloseableHttpResponse mockHttpResponse = MockHttp.response(HttpStatus.SC_CREATED);
-        when(mockHttpClient.execute(any(HttpRequestBase.class))).thenReturn(mockHttpResponse);
+        when(mockHttpClient.execute(any(HttpUriRequestBase.class))).thenReturn(mockHttpResponse);
 
         DatasetResponse mockDatasetResponse = mockDatasetResponse(mockHttpResponse);
         Dataset expectedDataset = mockDatasetResponse.getNext();
@@ -84,7 +85,7 @@ public class DatasetAPIClientTest {
         // When createDataset is called
         Dataset actualDataset = datasetAPIClient.createDataset(datasetID, dataset);
 
-        HttpEntityEnclosingRequestBase httpRequest = captureHttpRequestWithBody(mockHttpClient);
+        HttpUriRequestBase httpRequest = captureHttpRequestWithBody(mockHttpClient);
 
         // Then the request should contain the authentication header
         String actualAuthToken = httpRequest.getFirstHeader(authTokenHeaderName).getValue();
@@ -116,7 +117,7 @@ public class DatasetAPIClientTest {
         // Given a mock dataset API response that has unknown fields (fields that are not defined in the model)
 
         CloseableHttpResponse mockHttpResponse = MockHttp.response(HttpStatus.SC_CREATED);
-        when(mockHttpClient.execute(any(HttpRequestBase.class))).thenReturn(mockHttpResponse);
+        when(mockHttpClient.execute(any(HttpUriRequestBase.class))).thenReturn(mockHttpResponse);
 
         Dataset dataset = createDataset();
 
@@ -139,7 +140,7 @@ public class DatasetAPIClientTest {
 
         // Given a request to the dataset API that returns a 500
         CloseableHttpResponse mockHttpResponse = MockHttp.response(HttpStatus.SC_INTERNAL_SERVER_ERROR);
-        when(mockHttpClient.execute(any(HttpRequestBase.class))).thenReturn(mockHttpResponse);
+        when(mockHttpClient.execute(any(HttpUriRequestBase.class))).thenReturn(mockHttpResponse);
 
         Dataset dataset = new Dataset();
 
@@ -157,7 +158,7 @@ public class DatasetAPIClientTest {
 
         // Given a request to the dataset API that returns a 401
         CloseableHttpResponse mockHttpResponse = MockHttp.response(HttpStatus.SC_UNAUTHORIZED);
-        when(mockHttpClient.execute(any(HttpRequestBase.class))).thenReturn(mockHttpResponse);
+        when(mockHttpClient.execute(any(HttpUriRequestBase.class))).thenReturn(mockHttpResponse);
 
         Dataset dataset = new Dataset();
 
@@ -175,7 +176,7 @@ public class DatasetAPIClientTest {
 
         // Given a request to the dataset API that returns a 403
         CloseableHttpResponse mockHttpResponse = MockHttp.response(HttpStatus.SC_FORBIDDEN);
-        when(mockHttpClient.execute(any(HttpRequestBase.class))).thenReturn(mockHttpResponse);
+        when(mockHttpClient.execute(any(HttpUriRequestBase.class))).thenReturn(mockHttpResponse);
 
         Dataset dataset = new Dataset();
 
@@ -209,7 +210,7 @@ public class DatasetAPIClientTest {
 
         // Given a mock dataset response from the dataset API
         CloseableHttpResponse mockHttpResponse = MockHttp.response(HttpStatus.SC_OK);
-        when(mockHttpClient.execute(any(HttpRequestBase.class))).thenReturn(mockHttpResponse);
+        when(mockHttpClient.execute(any(HttpUriRequestBase.class))).thenReturn(mockHttpResponse);
 
         DatasetResponse mockDatasetResponse = mockDatasetResponse(mockHttpResponse);
         Dataset expectedDataset = mockDatasetResponse.getNext();
@@ -219,7 +220,7 @@ public class DatasetAPIClientTest {
 
         assertNotNull(actualDataset);
 
-        HttpRequestBase httpRequest = captureHttpRequest(mockHttpClient);
+        HttpUriRequestBase httpRequest = captureHttpRequest(mockHttpClient);
 
         // Then the request should contain the authentication header
         String actualAuthToken = httpRequest.getFirstHeader(authTokenHeaderName).getValue();
@@ -242,7 +243,7 @@ public class DatasetAPIClientTest {
 
         // Given a request to the dataset API that returns a 404
         CloseableHttpResponse mockHttpResponse = MockHttp.response(HttpStatus.SC_NOT_FOUND);
-        when(mockHttpClient.execute(any(HttpRequestBase.class))).thenReturn(mockHttpResponse);
+        when(mockHttpClient.execute(any(HttpUriRequestBase.class))).thenReturn(mockHttpResponse);
 
         // When getDataset is called
         // Then the expected exception is thrown
@@ -258,7 +259,7 @@ public class DatasetAPIClientTest {
 
         // Given a request to the dataset API that returns a 500
         CloseableHttpResponse mockHttpResponse = MockHttp.response(HttpStatus.SC_INTERNAL_SERVER_ERROR);
-        when(mockHttpClient.execute(any(HttpRequestBase.class))).thenReturn(mockHttpResponse);
+        when(mockHttpClient.execute(any(HttpUriRequestBase.class))).thenReturn(mockHttpResponse);
 
         // When getDataset is called
         // Then the expected exception is thrown
@@ -274,7 +275,7 @@ public class DatasetAPIClientTest {
 
         // Given a request to the dataset API that returns a 401
         CloseableHttpResponse mockHttpResponse = MockHttp.response(HttpStatus.SC_UNAUTHORIZED);
-        when(mockHttpClient.execute(any(HttpRequestBase.class))).thenReturn(mockHttpResponse);
+        when(mockHttpClient.execute(any(HttpUriRequestBase.class))).thenReturn(mockHttpResponse);
 
         // When getDataset is called
         // Then the expected exception is thrown
@@ -307,12 +308,12 @@ public class DatasetAPIClientTest {
         Dataset dataset = createDataset();
 
         CloseableHttpResponse mockHttpResponse = MockHttp.response(HttpStatus.SC_OK);
-        when(mockHttpClient.execute(any(HttpRequestBase.class))).thenReturn(mockHttpResponse);
+        when(mockHttpClient.execute(any(HttpUriRequestBase.class))).thenReturn(mockHttpResponse);
 
         // When updateDataset is called
         datasetAPIClient.updateDataset(datasetID, dataset);
 
-        HttpEntityEnclosingRequestBase httpRequest = captureHttpRequestWithBody(mockHttpClient);
+        HttpUriRequestBase httpRequest = captureHttpRequestWithBody(mockHttpClient);
 
         // Then the request should contain the authentication header
         String actualAuthToken = httpRequest.getFirstHeader(authTokenHeaderName).getValue();
@@ -338,7 +339,7 @@ public class DatasetAPIClientTest {
 
         // Given a request to the dataset API that returns a 404
         CloseableHttpResponse mockHttpResponse = MockHttp.response(HttpStatus.SC_NOT_FOUND);
-        when(mockHttpClient.execute(any(HttpRequestBase.class))).thenReturn(mockHttpResponse);
+        when(mockHttpClient.execute(any(HttpUriRequestBase.class))).thenReturn(mockHttpResponse);
 
         Dataset dataset = new Dataset();
 
@@ -356,7 +357,7 @@ public class DatasetAPIClientTest {
 
         // Given a request to the dataset API that returns a 401
         CloseableHttpResponse mockHttpResponse = MockHttp.response(HttpStatus.SC_UNAUTHORIZED);
-        when(mockHttpClient.execute(any(HttpRequestBase.class))).thenReturn(mockHttpResponse);
+        when(mockHttpClient.execute(any(HttpUriRequestBase.class))).thenReturn(mockHttpResponse);
 
         Dataset dataset = new Dataset();
 
@@ -374,7 +375,7 @@ public class DatasetAPIClientTest {
 
         // Given a request to the dataset API that returns a 400
         CloseableHttpResponse mockHttpResponse = MockHttp.response(HttpStatus.SC_BAD_REQUEST);
-        when(mockHttpClient.execute(any(HttpRequestBase.class))).thenReturn(mockHttpResponse);
+        when(mockHttpClient.execute(any(HttpUriRequestBase.class))).thenReturn(mockHttpResponse);
 
         Dataset dataset = new Dataset();
 
@@ -392,7 +393,7 @@ public class DatasetAPIClientTest {
 
         // Given a request to the dataset API that returns a 500
         CloseableHttpResponse mockHttpResponse = MockHttp.response(HttpStatus.SC_INTERNAL_SERVER_ERROR);
-        when(mockHttpClient.execute(any(HttpRequestBase.class))).thenReturn(mockHttpResponse);
+        when(mockHttpClient.execute(any(HttpUriRequestBase.class))).thenReturn(mockHttpResponse);
 
         Dataset dataset = new Dataset();
 
@@ -426,7 +427,7 @@ public class DatasetAPIClientTest {
 
         // Given a mock dataset response from the dataset API
         CloseableHttpResponse mockHttpResponse = MockHttp.response(HttpStatus.SC_OK);
-        when(mockHttpClient.execute(any(HttpRequestBase.class))).thenReturn(mockHttpResponse);
+        when(mockHttpClient.execute(any(HttpUriRequestBase.class))).thenReturn(mockHttpResponse);
 
         Instance expectedInstance = mockInstanceResponse(mockHttpResponse);
 
@@ -435,7 +436,7 @@ public class DatasetAPIClientTest {
 
         assertNotNull(actualInstance);
 
-        HttpRequestBase httpRequest = captureHttpRequest(mockHttpClient);
+        HttpUriRequestBase httpRequest = captureHttpRequest(mockHttpClient);
 
         // Then the request should contain the authentication header
         String actualAuthToken = httpRequest.getFirstHeader(authTokenHeaderName).getValue();
@@ -457,7 +458,7 @@ public class DatasetAPIClientTest {
 
         // Given a request to the dataset API that returns a 404
         CloseableHttpResponse mockHttpResponse = MockHttp.response(HttpStatus.SC_NOT_FOUND);
-        when(mockHttpClient.execute(any(HttpRequestBase.class))).thenReturn(mockHttpResponse);
+        when(mockHttpClient.execute(any(HttpUriRequestBase.class))).thenReturn(mockHttpResponse);
 
         // When getInstance is called
         // Then the expected exception is thrown
@@ -473,7 +474,7 @@ public class DatasetAPIClientTest {
 
         // Given a request to the dataset API that returns a 500
         CloseableHttpResponse mockHttpResponse = MockHttp.response(HttpStatus.SC_INTERNAL_SERVER_ERROR);
-        when(mockHttpClient.execute(any(HttpRequestBase.class))).thenReturn(mockHttpResponse);
+        when(mockHttpClient.execute(any(HttpUriRequestBase.class))).thenReturn(mockHttpResponse);
 
         // When getInstance is called
         // Then the expected exception is thrown
@@ -504,7 +505,7 @@ public class DatasetAPIClientTest {
 
         // Given a mock dataset response from the dataset API
         CloseableHttpResponse mockHttpResponse = MockHttp.response(HttpStatus.SC_OK);
-        when(mockHttpClient.execute(any(HttpRequestBase.class))).thenReturn(mockHttpResponse);
+        when(mockHttpClient.execute(any(HttpUriRequestBase.class))).thenReturn(mockHttpResponse);
 
         DatasetVersion expectedVersion = mockVersionResponse(mockHttpResponse);
 
@@ -513,7 +514,7 @@ public class DatasetAPIClientTest {
 
         assertNotNull(actualDatasetVersion);
 
-        HttpRequestBase httpRequest = captureHttpRequest(mockHttpClient);
+        HttpUriRequestBase httpRequest = captureHttpRequest(mockHttpClient);
 
         // Then the request should contain the authentication header
         String actualAuthToken = httpRequest.getFirstHeader(authTokenHeaderName).getValue();
@@ -535,7 +536,7 @@ public class DatasetAPIClientTest {
 
         // Given a request to the dataset API that returns a 404
         CloseableHttpResponse mockHttpResponse = MockHttp.response(HttpStatus.SC_NOT_FOUND);
-        when(mockHttpClient.execute(any(HttpRequestBase.class))).thenReturn(mockHttpResponse);
+        when(mockHttpClient.execute(any(HttpUriRequestBase.class))).thenReturn(mockHttpResponse);
 
         // When getDatasetVersion is called
         // Then the expected exception is thrown
@@ -551,7 +552,7 @@ public class DatasetAPIClientTest {
 
         // Given a request to the dataset API that returns a 401
         CloseableHttpResponse mockHttpResponse = MockHttp.response(HttpStatus.SC_UNAUTHORIZED);
-        when(mockHttpClient.execute(any(HttpRequestBase.class))).thenReturn(mockHttpResponse);
+        when(mockHttpClient.execute(any(HttpUriRequestBase.class))).thenReturn(mockHttpResponse);
 
         // When getDatasetVersion is called
         // Then the expected exception is thrown
@@ -567,7 +568,7 @@ public class DatasetAPIClientTest {
 
         // Given a request to the dataset API that returns a 500
         CloseableHttpResponse mockHttpResponse = MockHttp.response(HttpStatus.SC_INTERNAL_SERVER_ERROR);
-        when(mockHttpClient.execute(any(HttpRequestBase.class))).thenReturn(mockHttpResponse);
+        when(mockHttpClient.execute(any(HttpUriRequestBase.class))).thenReturn(mockHttpResponse);
 
         // When getDatasetVersion is called
         // Then the expected exception is thrown
@@ -615,12 +616,12 @@ public class DatasetAPIClientTest {
         DatasetVersion datasetVersion = createDatasetVersion();
 
         CloseableHttpResponse mockHttpResponse = MockHttp.response(HttpStatus.SC_OK);
-        when(mockHttpClient.execute(any(HttpRequestBase.class))).thenReturn(mockHttpResponse);
+        when(mockHttpClient.execute(any(HttpUriRequestBase.class))).thenReturn(mockHttpResponse);
 
         // When updateDatasetVersion is called
         datasetAPIClient.updateDatasetVersion(datasetID, edition, version, datasetVersion);
 
-        HttpEntityEnclosingRequestBase httpRequest = captureHttpRequestWithBody(mockHttpClient);
+        HttpUriRequestBase httpRequest = captureHttpRequestWithBody(mockHttpClient);
 
         // Then the request should contain the authentication header
         String actualAuthToken = httpRequest.getFirstHeader(authTokenHeaderName).getValue();
@@ -645,7 +646,7 @@ public class DatasetAPIClientTest {
 
         // Given a request to the dataset API that returns a 404
         CloseableHttpResponse mockHttpResponse = MockHttp.response(HttpStatus.SC_NOT_FOUND);
-        when(mockHttpClient.execute(any(HttpRequestBase.class))).thenReturn(mockHttpResponse);
+        when(mockHttpClient.execute(any(HttpUriRequestBase.class))).thenReturn(mockHttpResponse);
 
         DatasetVersion datasetVersion = createDatasetVersion();
 
@@ -663,7 +664,7 @@ public class DatasetAPIClientTest {
 
         // Given a request to the dataset API that returns a 401
         CloseableHttpResponse mockHttpResponse = MockHttp.response(HttpStatus.SC_UNAUTHORIZED);
-        when(mockHttpClient.execute(any(HttpRequestBase.class))).thenReturn(mockHttpResponse);
+        when(mockHttpClient.execute(any(HttpUriRequestBase.class))).thenReturn(mockHttpResponse);
 
         DatasetVersion datasetVersion = createDatasetVersion();
 
@@ -681,7 +682,7 @@ public class DatasetAPIClientTest {
 
         // Given a request to the dataset API that returns a 500
         CloseableHttpResponse mockHttpResponse = MockHttp.response(HttpStatus.SC_INTERNAL_SERVER_ERROR);
-        when(mockHttpClient.execute(any(HttpRequestBase.class))).thenReturn(mockHttpResponse);
+        when(mockHttpClient.execute(any(HttpUriRequestBase.class))).thenReturn(mockHttpResponse);
 
         DatasetVersion datasetVersion = createDatasetVersion();
 
@@ -699,12 +700,12 @@ public class DatasetAPIClientTest {
 
         // Given a mock dataset response from the dataset API
         CloseableHttpResponse mockHttpResponse = MockHttp.response(HttpStatus.SC_OK);
-        when(mockHttpClient.execute(any(HttpRequestBase.class))).thenReturn(mockHttpResponse);
+        when(mockHttpClient.execute(any(HttpUriRequestBase.class))).thenReturn(mockHttpResponse);
 
         // When detachVersion is called
         datasetAPIClient.detachVersion(datasetID, version, edition);
 
-        HttpRequestBase httpRequest = captureHttpRequest(mockHttpClient);
+        HttpUriRequestBase httpRequest = captureHttpRequest(mockHttpClient);
 
         // Then the request should contain the authentication header
         String actualAuthToken = httpRequest.getFirstHeader(authTokenHeaderName).getValue();
@@ -723,7 +724,7 @@ public class DatasetAPIClientTest {
 
         // Given a request to the dataset API that returns a 500
         CloseableHttpResponse mockHttpResponse = MockHttp.response(HttpStatus.SC_INTERNAL_SERVER_ERROR);
-        when(mockHttpClient.execute(any(HttpRequestBase.class))).thenReturn(mockHttpResponse);
+        when(mockHttpClient.execute(any(HttpUriRequestBase.class))).thenReturn(mockHttpResponse);
 
         // When detachVersion is called
         // Then the expected exception is thrown
@@ -739,7 +740,7 @@ public class DatasetAPIClientTest {
 
         // Given a request to the dataset API that returns a 401
         CloseableHttpResponse mockHttpResponse = MockHttp.response(HttpStatus.SC_UNAUTHORIZED);
-        when(mockHttpClient.execute(any(HttpRequestBase.class))).thenReturn(mockHttpResponse);
+        when(mockHttpClient.execute(any(HttpUriRequestBase.class))).thenReturn(mockHttpResponse);
 
         // When detachVersion is called
         // Then the expected exception is thrown
@@ -755,7 +756,7 @@ public class DatasetAPIClientTest {
 
         // Given a request to the dataset API that returns a 403
         CloseableHttpResponse mockHttpResponse = MockHttp.response(HttpStatus.SC_FORBIDDEN);
-        when(mockHttpClient.execute(any(HttpRequestBase.class))).thenReturn(mockHttpResponse);
+        when(mockHttpClient.execute(any(HttpUriRequestBase.class))).thenReturn(mockHttpResponse);
 
         // When detachVersion is called
         // Then the expected exception is thrown
@@ -816,12 +817,12 @@ public class DatasetAPIClientTest {
 
         // Given a mock dataset response from the dataset API
         CloseableHttpResponse mockHttpResponse = MockHttp.response(HttpStatus.SC_NO_CONTENT);
-        when(mockHttpClient.execute(any(HttpRequestBase.class))).thenReturn(mockHttpResponse);
+        when(mockHttpClient.execute(any(HttpUriRequestBase.class))).thenReturn(mockHttpResponse);
 
         // When deleteDataset is called
         datasetAPIClient.deleteDataset(datasetID);
 
-        HttpRequestBase httpRequest = captureHttpRequest(mockHttpClient);
+        HttpUriRequestBase httpRequest = captureHttpRequest(mockHttpClient);
 
         // Then the request should contain the authentication header
         String actualAuthToken = httpRequest.getFirstHeader(authTokenHeaderName).getValue();
@@ -840,7 +841,7 @@ public class DatasetAPIClientTest {
 
         // Given a request to the dataset API that returns a 500
         CloseableHttpResponse mockHttpResponse = MockHttp.response(HttpStatus.SC_INTERNAL_SERVER_ERROR);
-        when(mockHttpClient.execute(any(HttpRequestBase.class))).thenReturn(mockHttpResponse);
+        when(mockHttpClient.execute(any(HttpUriRequestBase.class))).thenReturn(mockHttpResponse);
 
         // When deleteDataset is called
         // Then the expected exception is thrown
@@ -871,7 +872,7 @@ public class DatasetAPIClientTest {
 
         // Given a request to the dataset API that returns a 403
         CloseableHttpResponse mockHttpResponse = MockHttp.response(HttpStatus.SC_FORBIDDEN);
-        when(mockHttpClient.execute(any(HttpRequestBase.class))).thenReturn(mockHttpResponse);
+        when(mockHttpClient.execute(any(HttpUriRequestBase.class))).thenReturn(mockHttpResponse);
 
         // When deleteDataset is called
         // Then the expected exception is thrown
@@ -916,14 +917,14 @@ public class DatasetAPIClientTest {
         return instance;
     }
 
-    private HttpEntityEnclosingRequestBase captureHttpRequestWithBody(CloseableHttpClient mockHttpClient) throws IOException {
-        ArgumentCaptor<HttpEntityEnclosingRequestBase> requestCaptor = ArgumentCaptor.forClass(HttpEntityEnclosingRequestBase.class);
+    private HttpUriRequestBase captureHttpRequestWithBody(CloseableHttpClient mockHttpClient) throws IOException {
+        ArgumentCaptor<HttpUriRequestBase> requestCaptor = ArgumentCaptor.forClass(HttpUriRequestBase.class);
         verify(mockHttpClient).execute(requestCaptor.capture());
         return requestCaptor.getValue();
     }
 
-    private HttpRequestBase captureHttpRequest(CloseableHttpClient mockHttpClient) throws IOException {
-        ArgumentCaptor<HttpRequestBase> requestCaptor = ArgumentCaptor.forClass(HttpRequestBase.class);
+    private HttpUriRequestBase captureHttpRequest(CloseableHttpClient mockHttpClient) throws IOException {
+        ArgumentCaptor<HttpUriRequestBase> requestCaptor = ArgumentCaptor.forClass(HttpUriRequestBase.class);
         verify(mockHttpClient).execute(requestCaptor.capture());
         return requestCaptor.getValue();
     }

--- a/src/test/java/dp/api/dataset/DatasetAPIClientTest.java
+++ b/src/test/java/dp/api/dataset/DatasetAPIClientTest.java
@@ -14,7 +14,6 @@ import dp.api.dataset.model.DatasetResponse;
 import dp.api.dataset.model.DatasetVersion;
 import dp.api.dataset.model.Instance;
 import org.apache.commons.io.IOUtils;
-import org.apache.hc.core5.http.ClassicHttpResponse;
 import org.apache.hc.core5.http.HttpStatus;
 import org.apache.hc.core5.http.io.entity.StringEntity;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;

--- a/src/test/java/dp/api/dataset/MockHttp.java
+++ b/src/test/java/dp/api/dataset/MockHttp.java
@@ -2,11 +2,8 @@ package dp.api.dataset;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.http.StatusLine;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.entity.StringEntity;
-
-import java.io.UnsupportedEncodingException;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.core5.http.io.entity.StringEntity;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -19,15 +16,12 @@ public class MockHttp {
     public static CloseableHttpResponse response(int httpStatus) {
 
         CloseableHttpResponse mockHttpResponse = mock(CloseableHttpResponse.class);
-
-        StatusLine mockResponseStatus = mock(StatusLine.class);
-        when(mockResponseStatus.getStatusCode()).thenReturn(httpStatus);
-        when(mockHttpResponse.getStatusLine()).thenReturn(mockResponseStatus);
+        when(mockHttpResponse.getCode()).thenReturn(httpStatus);
 
         return mockHttpResponse;
     }
 
-    public static void responseBody(CloseableHttpResponse mockHttpResponse, Object responseBody) throws JsonProcessingException, UnsupportedEncodingException {
+    public static void responseBody(CloseableHttpResponse mockHttpResponse, Object responseBody) throws JsonProcessingException {
         String responseJSON = json.writeValueAsString(responseBody);
         when(mockHttpResponse.getEntity()).thenReturn(new StringEntity(responseJSON));
     }

--- a/src/test/java/dp/api/dataset/RetryStrategyTest.java
+++ b/src/test/java/dp/api/dataset/RetryStrategyTest.java
@@ -1,9 +1,11 @@
 package dp.api.dataset;
 
-import org.apache.http.HttpResponse;
-import org.apache.http.HttpStatus;
-import org.apache.http.protocol.BasicHttpContext;
-import org.apache.http.protocol.HttpContext;
+import org.apache.hc.core5.http.HttpResponse;
+
+import org.apache.hc.core5.http.protocol.BasicHttpContext;
+import org.apache.hc.core5.http.protocol.HttpContext;
+
+import org.apache.hc.core5.http.HttpStatus;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -20,7 +22,11 @@ public class RetryStrategyTest {
     @Test
     void testRetryStrategy_getRetryInterval() {
 
-        assertEquals(RETRY_INTERVAL, retryStrategy.getRetryInterval());
+        HttpResponse httpResponse = MockHttp.response(HttpStatus.SC_INTERNAL_SERVER_ERROR);
+        int executionCount = 1;
+        HttpContext httpContext = new BasicHttpContext();
+
+        assertEquals(RETRY_INTERVAL, retryStrategy.getRetryInterval(httpResponse, executionCount, httpContext).toMilliseconds());
     }
 
     @Test


### PR DESCRIPTION
Upgraded dp-logging and correspondingly had to upgrade the apache http dependencies to client5. This also required adding mockito-inline as the client5 version of CloseableHttpResponse is not mockable with mockito core as it is final. 